### PR TITLE
Fix shell semantics in test command execution

### DIFF
--- a/docker_self/docker_service.py
+++ b/docker_self/docker_service.py
@@ -781,11 +781,12 @@ def execute_command_in_container(host_info: DockerHostInfo, container_id: str, c
     try:
         client = create_docker_client(host_info)
 
-        # Ensure command format
+        # String commands in test_commands.json are shell programs, not argv
+        # strings. Preserve operators such as &&, >, >>, &, and leading
+        # environment assignments by invoking an explicit shell. Callers that
+        # already have an argv vector can continue to pass a list directly.
         if isinstance(command, str):
-            # Use shlex.split to handle complex command strings with quotes and escapes
-            import shlex
-            command_list = shlex.split(command)
+            command_list = ["/bin/sh", "-lc", command]
         else:
             command_list = command
 

--- a/test_files/binaryalert/test_commands.json
+++ b/test_files/binaryalert/test_commands.json
@@ -1,1 +1,1 @@
-["set AWS_DEFAULT_REGION=us-east-1","pytest --continue-on-collection-errors tests"]
+["AWS_DEFAULT_REGION=us-east-1 pytest --continue-on-collection-errors tests"]

--- a/test_files/parse/test_commands.json
+++ b/test_files/parse/test_commands.json
@@ -1,1 +1,1 @@
-["pip install -e . & pip install -r tests/requirements.txt","pytest --continue-on-collection-errors"]
+["pip install -e . && pip install -r tests/requirements.txt","pytest --continue-on-collection-errors"]

--- a/tests/test_command_runner_regression.py
+++ b/tests/test_command_runner_regression.py
@@ -1,0 +1,83 @@
+import importlib
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+def import_docker_service_without_runtime_dependency():
+    """The command-construction tests do not require a running Docker daemon."""
+    fake_module = types.ModuleType("python_on_whales")
+    fake_module.DockerClient = type("DockerClient", (), {})
+    fake_module.Image = type("Image", (), {})
+    fake_module.Container = type("Container", (), {})
+    with patch.dict(sys.modules, {"python_on_whales": fake_module}):
+        return importlib.import_module("docker_self.docker_service")
+
+
+docker_service = import_docker_service_without_runtime_dependency()
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class ExecuteCommandRegressionTest(unittest.TestCase):
+    def test_string_command_is_executed_by_a_shell(self):
+        client = Mock()
+        client.container.execute.return_value = "ok"
+        command = "touch README.md && pip install -e ."
+
+        with patch.object(docker_service, "create_docker_client", return_value=client):
+            exit_code, output = docker_service.execute_command_in_container(
+                docker_service.DockerHostInfo("local"),
+                "container-id",
+                command,
+                workdir="/workspace",
+            )
+
+        self.assertEqual((exit_code, output), (0, "ok"))
+        client.container.execute.assert_called_once_with(
+            "container-id",
+            ["/bin/sh", "-lc", command],
+            user=None,
+            workdir="/workspace",
+        )
+
+    def test_explicit_argv_list_remains_direct_execution(self):
+        client = Mock()
+        client.container.execute.return_value = "ok"
+        command = ["pytest", "tests"]
+
+        with patch.object(docker_service, "create_docker_client", return_value=client):
+            docker_service.execute_command_in_container(
+                docker_service.DockerHostInfo("local"),
+                "container-id",
+                command,
+            )
+
+        client.container.execute.assert_called_once_with(
+            "container-id",
+            command,
+            user=None,
+            workdir=None,
+        )
+
+    def test_parse_installation_is_ordered(self):
+        commands = json.loads(
+            (REPO_ROOT / "test_files" / "parse" / "test_commands.json").read_text()
+        )
+        self.assertIn("pip install -e . && pip install -r", commands[0])
+        self.assertNotIn(" & ", commands[0])
+
+    def test_binaryalert_region_applies_to_pytest_process(self):
+        commands = json.loads(
+            (REPO_ROOT / "test_files" / "binaryalert" / "test_commands.json").read_text()
+        )
+        self.assertEqual(
+            commands,
+            ["AWS_DEFAULT_REGION=us-east-1 pytest --continue-on-collection-errors tests"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Candidate implementation for #13. String entries from `test_commands.json` are shell programs,
but the current runner tokenizes them with `shlex.split()` and passes the resulting argv directly
to `container.execute()`. This draft executes string commands through `/bin/sh -lc` while
preserving direct execution for callers that already pass an argv list.

## Changes

- execute string commands as `[/bin/sh, -lc, command]`;
- leave explicit list commands unchanged;
- change `parse` installation ordering from background `&` to conditional sequential `&&`;
- apply `AWS_DEFAULT_REGION` directly to the `binaryalert` pytest process;
- add Docker-independent regression tests for both runner modes and the two task-data corrections.

## Verification

```bash
PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover \
  -s tests -p 'test_command_runner_regression.py' -v
```

Four regression tests pass without requiring a Docker daemon. The independent process-level A/B
reproducer is available at https://github.com/wangkayn/nl2repobench-eval-audit.

### Real-image validation

The draft was also exercised against all seven public `linux/amd64` task images. Each legacy/fixed
pair used a fresh container with the same version-matched reference-source overlay and official
workspace sanitization.

The two clearest reference-input score-path changes are:

- `asteval`: 0/227 legacy, 227/227 fixed;
- `arxiv-mcp-server`: 0/23 legacy, 18/23 fixed.

The remaining tasks show the expected file, process, installation, or environment changes even
where the reference-input score is unchanged. Exact image digests, source commits, argv,
stdout/stderr, exit codes, timings, and file hashes are recorded in the
[real-image findings](https://github.com/wangkayn/nl2repobench-eval-audit/blob/334c5e0bc423e2b4abff3f8d6e0e67a788a12ab9/results/docker/full-reference-run/FINDINGS.md)
and [raw artifacts](https://github.com/wangkayn/nl2repobench-eval-audit/tree/334c5e0bc423e2b4abff3f8d6e0e67a788a12ab9/results/docker/full-reference-run).

Two independent findings are tracked separately: the `boto:1.0` image lacks `pytest` (#15), and
the `parse` suite reports 98 passed against a declared denominator of 96 (#16).

## Compatibility note

This intentionally changes grading semantics and may change scores relative to historical runs.
The PR is opened as a draft so the project can first decide whether the corrected behavior should
be gated behind a named grader version or accompanied by an explicit legacy mode. It does not claim
a numeric leaderboard delta; the real-image experiment uses controlled reference source, and paired
rescoring of the original generated workspaces remains separate work.
