### PR TITLE
docs: fill tested API contract gaps in Cerberus, Jinja and Cookiecutter

### DIFF
--- a/test_files/cerberus/start.md
+++ b/test_files/cerberus/start.md
@@ -161,6 +161,29 @@ from cerberus.errors import ValidationError
 Validator = InspectedValidator('Validator', (BareValidator,), {})
 ```
 
+**Validation and Callable Interface**:
+
+```python
+def validate(self, document, schema=None, update=False, normalize=True):
+    ...
+
+def __call__(self, document, schema=None, update=False, normalize=True):
+    ...
+```
+
+Calling a validator instance must have the same behavior as calling its `validate`
+method. In particular, `validator(document, schema, update)` must accept `update`
+as the third positional argument; it must not be keyword-only.
+
+- `document`: The mapping to validate.
+- `schema`: The validation schema, or `None` to use the schema already configured
+  on the validator.
+- `update`: Defaults to `False`. When `True`, skip checks for missing required
+  fields, while still validating the fields that are supplied.
+- `normalize`: Defaults to `True`; normalize the document before validation.
+- Return `True` when validation succeeds and `False` for validation-rule failures,
+  exposing the validation errors through the existing error-handling API.
+
 #### 3. _SchemaRuleTypeError Class
 
 **Function**: Raises an exception if the schema is not a dictionary.

--- a/test_files/cookiecutter/start.md
+++ b/test_files/cookiecutter/start.md
@@ -583,6 +583,15 @@ def load(
 
 **Return Value**: Dictionary of loaded context configurations.
 
+**Compatibility Requirements**: For a successful load, call
+`get_file_name(replay_dir, template_name)` exactly once to obtain the replay file
+path, forwarding both arguments unchanged. In particular, do not convert a
+string `replay_dir` to a `Path` before passing it to `get_file_name`; both APIs
+accept either representation, but the argument passed between them must retain
+the caller's representation. Read the opened replay file with one `json.load`
+call and return the loaded context. This internal call behavior is part of the
+upstream compatibility expected by this task, in addition to the returned data.
+
 #### 17. get_file_name() - Get Replay File Name
 
 **Function**: Get the name of file.

--- a/test_files/jinja/start.md
+++ b/test_files/jinja/start.md
@@ -2710,6 +2710,30 @@ def open_if_exists(filename: str, mode: str = "rb") -> t.IO[t.Any] | None:
         return None
     return open(filename, mode)
 ```
+#### 95a. consume
+
+**Function**: Iterate through all remaining items of an iterable, discarding the
+items. Return `None`. If an iterator is passed, that same iterator must be
+exhausted when the function returns.
+
+**Import**:
+```python
+from jinja2.utils import consume
+```
+
+**Function Signature**:
+```python
+def consume(iterable: t.Iterable[t.Any]) -> None:
+    ...
+```
+
+**Example**:
+```python
+values = iter(("first", "second"))
+consume(values)
+assert list(values) == []
+```
+
 #### 96. object_type_repr
 **Function**     Returns the name of the object's type.  For some recognized singletons the name of the object is returned instead. (For example for `None` and `Ellipsis`).
 **Parameter**     obj: The object to get the type name for.


### PR DESCRIPTION
## Summary

Related to #17. This is a narrow, documentation-only follow-up with three additional inspected cases; it does **not** resolve the full specification-completeness issue.

- **Cerberus:** document the callable validator signature, positional `update` argument, and validation/normalization flags.
- **Jinja:** add the missing `jinja2.utils.consume` import path, signature, and iterator-exhaustion behavior.
- **Cookiecutter:** state the replay-loading call contract already enforced by the upstream tests, including unchanged argument forwarding to `get_file_name`.

No evaluator, test, image, dependency, denominator, or generated solution is changed. These edits do change the input specifications for future runs, so results should continue to identify their benchmark revision.

## Why these additions are needed

Audited against benchmark commit `781a1da1ee41fb8edb0bed22f586d69111610edf` and the existing official task images.

| Task | Published specification before this change | Existing test requirement |
| --- | --- | --- |
| Cerberus | Says the validator is callable, but never names `update` or supplies the validator's call signature. The two existing `__call__` definitions belong to error-handler classes. | `/workspace/cerberus/tests/__init__.py:48,78` calls `validator(document, schema, update)`. |
| Jinja | `consume` does not occur anywhere in `start.md`. | `/workspace/tests/test_utils.py:10` imports `consume`; lines 189–194 require it to exhaust an iterator. A missing export prevents that file from being collected. |
| Cookiecutter | `load` and `get_file_name` both accept `Path | str`, but the specification does not require unchanged forwarding between them. | `/workspace/tests/replay/test_load.py:49` requires `get_file_name` to be called exactly once with the original arguments; lines 51–54 check JSON loading and the returned context. |

The Cookiecutter item is an internal-call compatibility constraint, not a claim that converting a string path to `Path` is inherently incorrect. This PR documents the existing grading contract instead of changing it. If maintainers prefer to relax that test, the documentation paragraph can be reconsidered separately.

The omissions have observable consequences in a locally inspected run: Cerberus repeatedly failed at the positional-argument boundary, Jinja failed to collect `test_utils.py`, and Cookiecutter failed the string-versus-`Path` call assertion. These observations do not establish how much a documentation fix will improve scores, or the prevalence of omissions across all 104 tasks.

## Verification

- Read the referenced test files directly from the already cached official images with networking disabled and a read-only container filesystem.
- Cross-checked Cerberus's signature and flags with [the upstream 1.3.7 validator](https://github.com/pyeve/cerberus/blob/1.3.7/cerberus/validator.py) and Jinja's return/iteration behavior with [the upstream 3.1.6 utility](https://github.com/pallets/jinja/blob/3.1.6/src/jinja2/utils.py).
- Checked the added Python signatures/examples for syntax.
- `git -c core.whitespace=cr-at-eol diff --check` (preserving the Cerberus document's existing CRLF line endings).
- The full benchmark was not rerun: this is a specification patch, not a reported score improvement.

### Inspected official image identities

These are the local image IDs recorded during inspection, not a claim about a separate registry manifest digest:

| Local tag | Image ID |
| --- | --- |
| `cerberus:1.0` | `sha256:3151e88fab1258b167baec972f8846b42f9538eefac76c6aae0f3c3c0c3f7b01` |
| `jinja:1.0` | `sha256:f7ef57cc166a054af5b9a484737880784352e47acba8816f2a55b12a115c4e4e` |
| `cookiecutter:1.0` | `sha256:637ea0894cabe851c20bacbc92484db20db7eff64cc4d389c69c53c83848ff6e` |
